### PR TITLE
Using Context for Sharing Service state across app

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import Home from './views/pages/Home';
 import LoadingScreen from './views/components/LoadingScreen';
 import AppContext from './contexts/AppContext';
 import RegisterModal from './addons/Modal/RegisterModal';
+import {ServiceContextProvider} from './contexts/ServiceContext';
 
 function AppLoader({children}) {
   const [loading, setLoading] = useState(true);
@@ -56,7 +57,6 @@ function AppRouter() {
         <Route path="/feed" element={<Feed />} />
         <Route path="/feed/message" element={<NewFeedMessage />} />
         <Route path="/inbox/new" element={<NewMessage />} />
-        
       </Routes>
       <Outlet />
     </>
@@ -68,16 +68,18 @@ function App() {
 
   return (
     <Router>
-      <AppContext.Provider
-        value={{
-          ...modal.value
-        }}
-      >
-        <AppLoader>
-          <AppRouter />
-        </AppLoader>
-        {modal.Component}
-      </AppContext.Provider>
+      <ServiceContextProvider>
+        <AppContext.Provider
+          value={{
+            ...modal.value
+          }}
+        >
+          <AppLoader>
+            <AppRouter />
+          </AppLoader>
+          {modal.Component}
+        </AppContext.Provider>
+      </ServiceContextProvider>
     </Router>
   );
 }

--- a/src/contexts/ServiceContext.js
+++ b/src/contexts/ServiceContext.js
@@ -1,0 +1,20 @@
+import {createContext, useContext} from 'react';
+import {MessageService} from '../services/Message.service';
+
+const ServiceContext = createContext({});
+
+/**
+ * @returns {{messageService: MessageService}}
+ */
+export const useServiceContext = () => useContext(ServiceContext);
+
+export const ServiceContextProvider = ({children}) => {
+  // all services get instantiated once and registered into the context provider
+  const messageService = new MessageService();
+
+  return (
+    <ServiceContext.Provider value={{messageService}}>
+      {children}
+    </ServiceContext.Provider>
+  );
+};

--- a/src/services/Message.service.js
+++ b/src/services/Message.service.js
@@ -1,6 +1,6 @@
 import {BehaviorSubject} from 'rxjs';
 
-class MessageService {
+export class MessageService {
   _messages = new BehaviorSubject([]);
   _count = 0;
 
@@ -28,5 +28,3 @@ class MessageService {
     }, 3_000);
   }
 }
-
-export default MessageService;

--- a/src/views/pages/Feed/index.js
+++ b/src/views/pages/Feed/index.js
@@ -1,11 +1,24 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import PageContainer from '../../components/PageContainer';
 import PageTitle from '../../components/PageTitle';
 import Text from '../../components/Text';
-import Button from '../../components/Button';
 import FeedSubNav from '../../components/FeedSubNav';
+import {useServiceContext} from '../../../contexts/ServiceContext';
 
 function Feed() {
+  const {messageService} = useServiceContext();
+  const [messages, setMessages] = useState([]);
+
+  useEffect(() => {
+    const sub = messageService.messages$.subscribe((message) => {
+      setMessages(message.map((m) => JSON.stringify(m)) ?? []);
+    });
+
+    return () => {
+      sub.unsubscribe();
+    };
+  }, []);
+
   return (
     <PageContainer>
       <div className="flex flex-row">
@@ -17,6 +30,9 @@ function Feed() {
           <Text>
             Some text explaining what this is all about and what to expect.
           </Text>
+          <div>
+            {React.Children.toArray(messages.map((m) => <div>{m}</div>))}
+          </div>
         </div>
       </div>
     </PageContainer>

--- a/src/views/pages/Navigation/TailwindyNav.jsx
+++ b/src/views/pages/Navigation/TailwindyNav.jsx
@@ -21,8 +21,11 @@ function TailwindyNav() {
             <span className="block relative w-6 h-px rounded-sm bg-white mt-1"></span>
           </button>
         </div>
-        <div class="lg:flex flex-grow items-center" id="example-navbar-warning">
-          <ul class="flex flex-col lg:flex-row list-none ml-auto">
+        <div
+          className="lg:flex flex-grow items-center"
+          id="example-navbar-warning"
+        >
+          <ul className="flex flex-col lg:flex-row list-none ml-auto">
             {React.Children.toArray(
               [
                 <Link to="/identity" className="link">


### PR DESCRIPTION
This implementation avoids prop-drilling and the state contained within each service will be shared across the entire client-side app