### PR TITLE
Event Driven Balance Updates

### DIFF
--- a/src/services/AccountBalance.service.js
+++ b/src/services/AccountBalance.service.js
@@ -2,12 +2,16 @@ import {ApiRx} from '@polkadot/api';
 import {BehaviorSubject, filter, switchMap} from 'rxjs';
 import KeyManager from './KeyManager';
 
-class ChainAccountService {
+class AccountBalanceService {
   /**
    * @private
    */
   _balance = new BehaviorSubject(0);
   balance$ = this._balance.asObservable();
+
+  get balance() {
+    return this._balance.value;
+  }
 
   /**
    * @private
@@ -43,4 +47,4 @@ class ChainAccountService {
   }
 }
 
-export default ChainAccountService;
+export default AccountBalanceService;

--- a/src/services/ChainAccountService.js
+++ b/src/services/ChainAccountService.js
@@ -1,0 +1,46 @@
+import {ApiRx} from '@polkadot/api';
+import {BehaviorSubject, filter, switchMap} from 'rxjs';
+import KeyManager from './KeyManager';
+
+class ChainAccountService {
+  /**
+   * @private
+   */
+  _balance = new BehaviorSubject(0);
+  balance$ = this._balance.asObservable();
+
+  /**
+   * @private
+   */
+  _api;
+
+  /**
+   * @private
+   */
+  _keyManager;
+
+  /**
+   * @param {ApiRx} api
+   * @param {KeyManager} keyManager
+   */
+  constructor(api, keyManager) {
+    this._api = api;
+    this._keyManager = keyManager;
+  }
+
+  listenForBalanceChanges() {
+    return this._keyManager.pair$
+      .pipe(
+        filter((a) => !!a),
+        switchMap((a) => this._api.query.system.account(a.address))
+      )
+      .subscribe(({nonce, data: balance}) => {
+        this._balance.next(balance.free.toString());
+        console.log(
+          `free balance is ${balance.free} with ${balance.reserved} reserved and a nonce of ${nonce}`
+        );
+      });
+  }
+}
+
+export default ChainAccountService;

--- a/src/services/Node/index.js
+++ b/src/services/Node/index.js
@@ -15,13 +15,6 @@ class Node {
    * @type {BehaviorSubject}
    * @private
    */
-  _balance = new BehaviorSubject(0);
-  balance$ = this._balance.asObservable();
-
-  /**
-   * @type {BehaviorSubject}
-   * @private
-   */
   _fee = new BehaviorSubject(0);
   fee$ = this._fee.asObservable();
 
@@ -43,24 +36,6 @@ class Node {
    */
   constructor(api) {
     this._api = api;
-  }
-
-  getBalance(keymanager) {
-    try {
-      if (!keymanager.signer()) {
-        this._balance.next(0);
-      } else {
-        this.api().then(async (a) => {
-          const {_, data: balance} = await a.query.system.account(
-            keymanager.signer().address
-          );
-          const amount = balance?.free ?? 0;
-          this._balance.next(`${amount}`);
-        });
-      }
-    } catch (err) {
-      console.error(err);
-    }
   }
 
   async getFeeForCreateIdentity(keymanager) {

--- a/src/utils/loadPolkadotApi.js
+++ b/src/utils/loadPolkadotApi.js
@@ -1,8 +1,9 @@
-import {ApiPromise, WsProvider} from '@polkadot/api';
+import {ApiPromise, ApiRx, WsProvider} from '@polkadot/api';
 import {NODE_URI_WS} from '../config';
 
 function connect() {
-  return new ApiPromise({provider: new WsProvider(`${NODE_URI_WS}`)});
+  const options = {provider: new WsProvider(`${NODE_URI_WS}`)};
+  return {rxjs: new ApiRx(options), promise: new ApiPromise(options)};
 }
 
 export default connect;

--- a/src/views/hooks/useAccount.jsx
+++ b/src/views/hooks/useAccount.jsx
@@ -3,18 +3,31 @@ import {filter} from 'rxjs';
 import {useServiceContext} from '../../contexts/ServiceContext';
 
 export function useAccount() {
-  const {keymanager} = useServiceContext();
+  const {keymanager, accountBalanceService} = useServiceContext();
   const [account, setAccount] = useState(undefined);
+  const [balance, setBalance] = useState(accountBalanceService.balance);
 
   useEffect(() => {
-    const sub = keymanager.pair$.pipe(filter((a) => !!a)).subscribe((a) => {
-      setAccount(a);
-    });
+    let subscriptions = [];
+
+    subscriptions.push(
+      keymanager.pair$.pipe(filter((a) => !!a)).subscribe((a) => {
+        setAccount(a);
+      })
+    );
+
+    subscriptions.push(
+      accountBalanceService.balance$.subscribe((d) => {
+        setBalance(d);
+      })
+    );
 
     return () => {
-      sub.unsubscribe();
+      subscriptions.forEach((s) => {
+        s.unsubscribe();
+      });
     };
   }, []);
 
-  return account;
+  return {account, balance};
 }

--- a/src/views/pages/Identity/index.jsx
+++ b/src/views/pages/Identity/index.jsx
@@ -8,28 +8,22 @@ import TransactionConfirm from '../../../addons/Modal/TransactionConfirm';
 import {useAccount} from '../../hooks/useAccount';
 
 function Identity() {
-  const account = useAccount();
+  const {account, balance} = useAccount();
   const [createIdentity, setCreateIdentity] = useState(true);
   const [btnEnabled, setBtnEnabled] = useState(false);
   const {keymanager, node} = useServiceContext();
   const [fee, setFee] = useState(0);
-  const [balance, setBalance] = useState(0);
   const [visible, setVisible] = useState(false);
   const [confirmed, setConfirmed] = useState(false);
 
   useEffect(() => {
-    const balance_sub = node.balance$.subscribe((d) => {
-      setBalance(d);
-    });
     const fee_sub = node.fee$.subscribe((d) => {
       setFee(d);
     });
 
-    node.getBalance(keymanager);
     node.getFeeForCreateIdentity(keymanager);
 
     return () => {
-      balance_sub.remove();
       fee_sub.remove();
     };
   }, []);
@@ -66,12 +60,8 @@ function Identity() {
         {confirmed && (
           <Text>Request sent - wait a moment for your identity number.</Text>
         )}
-        {!account && (
-          <Text>Create or restore a Fennel account first.</Text>
-        )}
-        {account && balance < fee && (
-          <Text>Insufficient balance.</Text>
-        )}
+        {!account && <Text>Create or restore a Fennel account first.</Text>}
+        {account && balance < fee && <Text>Insufficient balance.</Text>}
         {account && balance > fee && !confirmed && (
           <div>
             <Text>

--- a/src/views/pages/Navigation/TailwindyNav.jsx
+++ b/src/views/pages/Navigation/TailwindyNav.jsx
@@ -4,22 +4,17 @@ import {useServiceContext} from '../../../contexts/ServiceContext';
 import queryChainConnection from '../../hooks/queryChainConnection';
 
 function TailwindyNav() {
-  const {node, keymanager} = useServiceContext();
-  const [balance, setBalance] = useState(0);
+  const {chainAccountService} = useServiceContext();
   const connectedToChain = queryChainConnection();
+  const [balance, setBalance] = useState(0);
 
   useEffect(() => {
-    const sub = node.balance$.subscribe((d) => {
+    const sub = chainAccountService.balance$.subscribe((d) => {
       setBalance(d);
     });
 
-    let id = setInterval(() => {
-      node.getBalance(keymanager);
-    }, 1000);
-
     return () => {
       sub.remove();
-      clearInterval(id);
     };
   }, []);
 

--- a/src/views/pages/Navigation/TailwindyNav.jsx
+++ b/src/views/pages/Navigation/TailwindyNav.jsx
@@ -1,22 +1,11 @@
-import React, {useState, useEffect} from 'react';
+import React from 'react';
 import {Link} from 'react-router-dom';
-import {useServiceContext} from '../../../contexts/ServiceContext';
 import queryChainConnection from '../../hooks/queryChainConnection';
+import {useAccount} from '../../hooks/useAccount';
 
 function TailwindyNav() {
-  const {chainAccountService} = useServiceContext();
   const connectedToChain = queryChainConnection();
-  const [balance, setBalance] = useState(0);
-
-  useEffect(() => {
-    const sub = chainAccountService.balance$.subscribe((d) => {
-      setBalance(d);
-    });
-
-    return () => {
-      sub.remove();
-    };
-  }, []);
+  const {balance} = useAccount();
 
   return (
     <nav className="relative flex flex-wrap items-center justify-between px-2 py-3 bg-amber-500 mb-3">

--- a/src/views/pages/NewFeedMessage/Index.js
+++ b/src/views/pages/NewFeedMessage/Index.js
@@ -5,30 +5,26 @@ import FeedSubNav from '../../components/FeedSubNav';
 import {useServiceContext} from '../../../contexts/ServiceContext';
 import TransactionConfirm from '../../../addons/Modal/TransactionConfirm';
 import Text from '../../components/Text';
+import {useAccount} from '../../hooks/useAccount';
 
 function NewFeedMessage() {
   const {node, keymanager} = useServiceContext();
+  const {balance} = useAccount();
 
   const [value, setValue] = useState('');
   const [fee, setFee] = useState(0);
-  const [balance, setBalance] = useState(0);
   const [visible, setVisible] = useState(false);
   const [error, setError] = useState(undefined);
   const [success, setSuccess] = useState(false);
 
   useEffect(() => {
-    const balance_sub = node.balance$.subscribe((d) => {
-      setBalance(d);
-    });
     const fee_sub = node.fee$.subscribe((d) => {
       setFee(d);
     });
 
-    node.getBalance(keymanager);
     node.getFeeForSendNewSignal(keymanager, value);
 
     return () => {
-      balance_sub.remove();
       fee_sub.remove();
     };
   }, [value]);

--- a/src/views/pages/PublishKey/index.js
+++ b/src/views/pages/PublishKey/index.js
@@ -6,16 +6,17 @@ import {useServiceContext} from '../../../contexts/ServiceContext';
 import {useDefaultIdentity} from '../../hooks/useDefaultIdentity';
 import {usePublishKeyForm} from './usePublishKeyForm';
 import TransactionConfirm from '../../../addons/Modal/TransactionConfirm';
+import {useAccount} from '../../hooks/useAccount';
 
 function PublishKey() {
   const {node, keymanager, contactsManager} = useServiceContext();
   const defaultIdentity = useDefaultIdentity();
+  const {balance} = useAccount();
 
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState(undefined);
   const [visible, setVisible] = useState(false);
   const [fee, setFee] = useState(0);
-  const [balance, setBalance] = useState(0);
 
   const [fingerprint, location, PublishKeyForm] = usePublishKeyForm({
     onSubmit: () => {
@@ -25,18 +26,13 @@ function PublishKey() {
   });
 
   useEffect(() => {
-    const balance_sub = node.balance$.subscribe((d) => {
-      setBalance(d);
-    });
     const fee_sub = node.fee$.subscribe((d) => {
       setFee(d);
     });
 
-    node.getBalance(keymanager);
     node.getFeeForAnnounceKey(keymanager, fingerprint, location);
 
     return () => {
-      balance_sub.remove();
       fee_sub.remove();
     };
   }, [fingerprint, location]);

--- a/src/views/pages/RevokeKey/index.js
+++ b/src/views/pages/RevokeKey/index.js
@@ -5,31 +5,27 @@ import IdentitySubNav from '../../components/IdentitySubNav';
 import TransactionConfirm from '../../../addons/Modal/TransactionConfirm';
 import {useServiceContext} from '../../../contexts/ServiceContext';
 import {useDefaultIdentity} from '../../hooks/useDefaultIdentity';
+import {useAccount} from '../../hooks/useAccount';
 
 function RevokeKey() {
   const {node, keymanager} = useServiceContext();
   const defaultIdentity = useDefaultIdentity();
+  const {balance} = useAccount();
 
   const [fee, setFee] = useState(0);
-  const [balance, setBalance] = useState(0);
   const [confirmed, setConfirmed] = useState(false);
   const [visible, setVisible] = useState(false);
   const [fingerprint, setFingerprint] = useState('');
   const [success, setSuccess] = useState(false);
 
   useEffect(() => {
-    const balance_sub = node.balance$.subscribe((d) => {
-      setBalance(d);
-    });
     const fee_sub = node.fee$.subscribe((d) => {
       setFee(d);
     });
 
-    node.getBalance(keymanager);
     node.getFeeForRevokeKey(keymanager, fingerprint);
 
     return () => {
-      balance_sub.remove();
       fee_sub.remove();
     };
   }, [fingerprint]);


### PR DESCRIPTION
motivations
---
- Remove `setInterval` because its use is (1) difficult to debug (2) causes unnecessary data updates (3) unnecessarily increases load on client and server
- Use the fact that websockets are two ways. The balance changes are pushed from the server to the client. We can listen to those events and update the balance on the client side without having to long-poll the substrate node using `setInterval`. Instead of using `ApiPromise`, the rxjs implementation `RxPromise` was used to take advantage of its asynchronous data control capabilities.
- reduce the scope and complexity of the `Node` service by creating a single purpose service `AccountBalanceService`