### PR TITLE
rsa_encrypt/race-condition

### DIFF
--- a/src/views/pages/Inbox/index.js
+++ b/src/views/pages/Inbox/index.js
@@ -37,8 +37,8 @@ function Inbox() {
   const defaultSender = useDefaultSender();
 
   useEffect(() => {
-    const sub = messageService.received_messages$.subscribe((d) => {
-      setMessageList(d && d.length > 0 ? d : null);
+    const sub = messageService.received_messages$.subscribe((messages) => {
+      setMessageList(messages);
     });
 
     if (!!defaultSender) {
@@ -46,9 +46,9 @@ function Inbox() {
     }
 
     return () => {
-      sub.remove();
+      sub.unsubscribe();
     };
-  }, [defaultSender, messageService]);
+  }, [defaultSender]);
 
   return (
     <div className="flex flex-row">

--- a/src/views/pages/NewMessage/index.jsx
+++ b/src/views/pages/NewMessage/index.jsx
@@ -86,7 +86,7 @@ function NewMessage() {
   const submitMessage = async (e) => {
     e.preventDefault();
     let signature = 'TEST'; // This will be replaced by a call to RPC->sign.
-    if (
+    setSuccess(
       await messageService.sendMessage(
         state.message,
         state.fingerprint,
@@ -96,11 +96,7 @@ function NewMessage() {
         recipient,
         state.message_encryption_indicator
       )
-    ) {
-      setSuccess(true);
-    } else {
-      setSuccess(false);
-    }
+    );
   };
 
   const recipients = recipientsList.map((item) => (


### PR DESCRIPTION
- uses promises to avoid race conditions
- prefer to return promises or async/await (which will return a promise)
- the `message_encryption_indicator` property on the data object returned from the `api/messages/` endpoint does not include the `:1234` port. So instead of comparing the whole string, just checking the end which is the important part
- moved some logic into their own local methods to declutter