### PR TITLE
Fixes a TransactionConfirm crash.

### DIFF
--- a/src/views/pages/NewFeedMessage/Index.js
+++ b/src/views/pages/NewFeedMessage/Index.js
@@ -62,6 +62,7 @@ function NewFeedMessage() {
               setVisible(false);
               sendNewSignal(keymanager, value);
             }}
+            onCancel={() => setVisible(false)}
           />
         )}
         {error && (


### PR DESCRIPTION
If our TransactionConfirm component doesn't get an onCancel, it tries to call a function that doesn't exist. That happened here.